### PR TITLE
Default IPv6 pod CIDR should be /64, not /16

### DIFF
--- a/pkg/internal/apis/config/default.go
+++ b/pkg/internal/apis/config/default.go
@@ -58,7 +58,7 @@ func SetDefaultsCluster(obj *Cluster) {
 			obj.Networking.PodSubnet = "fd00:10:244::/64"
 		}
 		if obj.Networking.IPFamily == "DualStack" {
-			obj.Networking.PodSubnet = "10.244.0.0/16,fd00:10:244::/16"
+			obj.Networking.PodSubnet = "10.244.0.0/16,fd00:10:244::/64"
 		}
 	}
 	// default the service CIDR using the kubeadm default


### PR DESCRIPTION
@aojea I noticed there was still one case of the /16 bug in your code.  It probably doesn't come into play in practice, but still seems worth fixing for consistency.  (cc @song-jiang)